### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ For any questions or advices about this book, ask [mail@geraudmathe.com](mailto:
 8. __[Appendix](#appendix)__
 
 <a name="foreword"></a>
-##Foreword
+## Foreword
 
 <a name="foreword_1"></a>
 ### Why this guide ?


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
